### PR TITLE
Disable qdc by default, make it configurable

### DIFF
--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -11,7 +11,10 @@
       - restart redpanda-tuner
       - restart redpanda
     vars:
+      # we need to resolve existing variables using d() | bool in order to
+      # coerce missing values, empty strings, etc into a boolean type
       use_public_ips: "{{ advertise_public_ips | d() | bool }}"
+      enable_qdc_resolved: "{{ enable_qdc | d() | bool }}"
     shell: |
       set -e
       rpk config set cluster_id 'redpanda'
@@ -30,10 +33,13 @@
       }' --format yaml
       sudo rpk mode production
 
-      sudo rpk config set redpanda.kafka_qdc_enable true
-      sudo rpk config set redpanda.kafka_qdc_idle_depth 8
-      sudo rpk config set redpanda.kafka_qdc_max_depth 32
-      sudo rpk config set redpanda.kafka_qdc_max_latency_ms 4
+      {% if enable_qdc_resolved %}
+        sudo rpk config set redpanda.kafka_qdc_enable true
+        sudo rpk config set redpanda.kafka_qdc_idle_depth 8
+        sudo rpk config set redpanda.kafka_qdc_max_depth 32
+        sudo rpk config set redpanda.kafka_qdc_max_latency_ms 4
+      {% endif %}
+
       sudo rpk config set redpanda.rpc_server_tcp_recv_buf 65536
 
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -1,0 +1,5 @@
+# If set to true, the redpanda configuraiton will be set such
+# that it listens on the host public IPs rather than the local/VPC
+# IP addresses, which enables access from outside the local network
+# or VPC.
+advertise_public_ips: true

--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -3,3 +3,8 @@
 # IP addresses, which enables access from outside the local network
 # or VPC.
 advertise_public_ips: true
+
+# If set to true, queue depth control will be enabled with values
+# (see start-redpanda.yaml) appropriate for a small cluster
+# when redpanda is deployed
+enable_qdc: false


### PR DESCRIPTION
Curently QDC (queue depth control) is enabled by default, but as
this can be detrimental to performance this we now disable it by
default. However, it can be enabled again with the existing
values by setting enable_qdc true when running the
playbook.