### PR TITLE
Remove QDC from ansible deployment

### DIFF
--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -30,10 +30,6 @@
       }' --format yaml
       sudo rpk mode production
 
-      sudo rpk config set redpanda.kafka_qdc_enable true
-      sudo rpk config set redpanda.kafka_qdc_idle_depth 8
-      sudo rpk config set redpanda.kafka_qdc_max_depth 32
-      sudo rpk config set redpanda.kafka_qdc_max_latency_ms 4
       sudo rpk config set redpanda.rpc_server_tcp_recv_buf 65536
 
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}


### PR DESCRIPTION
Curently QDC (queue depth control) is enabled by default, but as
this can be detrimental to performance this we now disable it
for now.