### PR TITLE
Change mount fstab options for attached disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Available Ansible variables:
 You can pass the following variables as `-e var=value`:
 * `advertise_public_ips=false|true`: Configure Redpanda to advertise the node's public IPs for client communication instead of private IPs. This allows for using the cluster from outside its subnet. **Note**: This is not recommended for production deployments, because it means that your nodes will be public. Use it for testing only. Default `false`
 * `grafana_admin_pass=<password_here>`: Configure Grafana's admin user's password
+* `ephemeral_disk`: Enable filesystem check for attached disk, useful when using attached disks in instances with ephemeral OS disks (i.e Azure L Series). This allows a filesystem repair at boot time and ensures that the drive is remounted automatically after a reboot. Default `false` 
 
 2. Use `rpk` & standard Kafka tools to produce/consume from the Redpanda cluster & access the Grafana installation on the monitor host.
 * The Grafana URL is http://&lt;grafana host&gt;:3000/login

--- a/ansible/playbooks/prepare-data-dir.yml
+++ b/ansible/playbooks/prepare-data-dir.yml
@@ -9,6 +9,8 @@
     when: device_info[item]["partitions"] | length == 0
   - set_fact:
       nvme_devices_for_raid: '{{ (nvme_devices_for_raid | default([])) }}'
+  - set_fact:
+      ephemeral_disk: '{{ (ephemeral_disk | default(false)) }}'
 
   - block:
     - name: define mdadm_arrays variable
@@ -36,6 +38,9 @@
         path: /mnt/vectorized
         src: '{{ nvme_devices_for_raid[0] }}'
         fstype: xfs
+        opts: "{{ 'defaults,nofail' if ephemeral_disk else 'defaults'}}"
+        dump: "{{ 1 if ephemeral_disk else 0}}"
+        passno: "{{ 2 if ephemeral_disk else 0}}"
         state: mounted
     when: nvme_devices_for_raid|length == 1
 


### PR DESCRIPTION
This option will be enabled at runtime via
`--extra-vars` when running the ansible playbook.

When using an attached disk on an
ephemeral-disk-instance the mounts might be
deleted if a node is restarted/stopped, so we are
changing the ftsab options to:
```
  fs_freq/dump 1 - enables dump (if installed)
                   for this filesystem.
  fs_passno    2 - filesystem checker order,
                   should be 2 for non-root FS if
                   we want fscheck to check/repair
                   our fs.
```
This will enable us to repair the mount if the
ephemeral-disk-instance mess up the mount at boot
time.

Tested in Azure L Series VM.