### PR TITLE
Enable high availability and rack awareness on AWS

### DIFF
--- a/ansible/playbooks/deploy-prometheus-grafana.yml
+++ b/ansible/playbooks/deploy-prometheus-grafana.yml
@@ -10,6 +10,11 @@
       dest: '{{ playbook_dir }}/grafana_dashboards/redpanda-grafana.json'
       flat: yes
 
+- hosts: monitor
+  tasks:
+  - name: install deps
+    shell: |
+      sudo apt install -y python3-jmespath
 
 - hosts: monitor
   roles:

--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -7,16 +7,13 @@
       state: directory
 
   - name: configure redpanda
-    notify:
-      - restart redpanda-tuner
-      - restart redpanda
     vars:
       use_public_ips: "{{ advertise_public_ips | d() | bool }}"
     shell: |
       set -e
-      rpk config set cluster_id 'redpanda'
-      rpk config set organization 'redpanda-test'
-      rpk config set redpanda.advertised_kafka_api '{
+      sudo -u redpanda rpk redpanda config set cluster_id 'redpanda'
+      sudo -u redpanda rpk redpanda config set organization 'redpanda-test'
+      sudo -u redpanda rpk redpanda config set redpanda.advertised_kafka_api '{
       {% if use_public_ips %}
         address: {{ inventory_hostname }},
       {% else %}
@@ -24,27 +21,49 @@
       {% endif %}
         port: 9092
       }' --format yaml
-      rpk config set redpanda.advertised_rpc_api '{
+      sudo -u redpanda rpk redpanda config set redpanda.advertised_rpc_api '{
         address: {{ hostvars[inventory_hostname].private_ip }},
         port: 33145
       }' --format yaml
-      sudo rpk mode production
-
-      sudo rpk config set redpanda.rpc_server_tcp_recv_buf 65536
-
+      sudo -u redpanda rpk redpanda mode production
+      sudo -u redpanda rpk redpanda config set redpanda.rpc_server_tcp_recv_buf 65536
       {% if hostvars[groups['redpanda'][0]].id == hostvars[inventory_hostname].id %}
-      sudo rpk config bootstrap \
+      sudo -u redpanda rpk redpanda config bootstrap \
         --id {{ hostvars[inventory_hostname].id }} \
         --self {{ hostvars[inventory_hostname].private_ip }}
-
       {% else %}
-
-      sudo rpk config bootstrap \
+      sudo -u redpanda rpk redpanda config bootstrap \
         --id {{ hostvars[inventory_hostname].id }} \
         --self {{ hostvars[inventory_hostname].private_ip }} \
         --ips {{ groups["redpanda"] | map('extract', hostvars) | map(attribute='private_ip') | join(',') }}
       {% endif %}
 
+  - name: start redpanda-tuner
+    systemd:
+      name: redpanda-tuner
+      state: started
+  - name: start redpanda
+    systemd:
+      name: redpanda
+      state: started
+
+  - name: enable rack awareness
+    notify:
+      - restart redpanda-tuner
+      - restart redpanda
+    vars:
+      use_public_ips: "{{ advertise_public_ips | d() | bool }}"
+    shell: |
+      set -e
+      sudo -u redpanda rpk redpanda config set redpanda.rack {{ rack }}
+      {% if use_public_ips %}
+      sudo -u redpanda rpk cluster config set enable_rack_awareness true \
+        --api-urls {{ groups["redpanda"] | map('extract', hostvars) | map(attribute='inventory_hostname') | product([':9644']) | map('join') | join(',') }}
+      {% else %}
+      sudo -u redpanda rpk cluster config set enable_rack_awareness true \
+        --api-urls {{ groups["redpanda"] | map('extract', hostvars) | map(attribute='private_ip') | product([':9644']) | map('join') | join(',') }}
+      {% endif %}
+    when: rack is defined and rack != -1
 
   handlers:
   - name: restart redpanda-tuner

--- a/ansible/playbooks/start-redpanda.yml
+++ b/ansible/playbooks/start-redpanda.yml
@@ -48,9 +48,6 @@
       state: started
 
   - name: enable rack awareness
-    notify:
-      - restart redpanda-tuner
-      - restart redpanda
     vars:
       use_public_ips: "{{ advertise_public_ips | d() | bool }}"
     shell: |
@@ -64,13 +61,3 @@
         --api-urls {{ groups["redpanda"] | map('extract', hostvars) | map(attribute='private_ip') | product([':9644']) | map('join') | join(',') }}
       {% endif %}
     when: rack is defined and rack != -1
-
-  handlers:
-  - name: restart redpanda-tuner
-    systemd:
-      name: redpanda-tuner
-      state: restarted
-  - name: restart redpanda
-    systemd:
-      name: redpanda
-      state: restarted

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -96,7 +96,7 @@ resource "aws_security_group" "node_sec_group" {
     from_port   = 9644
     to_port     = 9644
     protocol    = "tcp"
-    self        = true
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   # grafana

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -3,8 +3,8 @@ resource "random_uuid" "cluster" {}
 resource "time_static" "timestamp" {}
 
 locals {
-  uuid = random_uuid.cluster.result
-  timestamp = time_static.timestamp.rfc3339
+  uuid          = random_uuid.cluster.result
+  timestamp     = time_static.timestamp.rfc3339
   deployment_id = "redpanda-${local.uuid}-${local.timestamp}"
 
   # tags shared by all instances
@@ -22,8 +22,7 @@ resource "aws_instance" "redpanda" {
   vpc_security_group_ids     = [aws_security_group.node_sec_group.id]
   placement_group            = var.ha ? aws_placement_group.redpanda-pg[0].id : null
   placement_partition_number = var.ha ? (count.index % aws_placement_group.redpanda-pg[0].partition_count) + 1 : null
-
-  tags                   = local.instance_tags
+  tags                       = local.instance_tags
 
   connection {
     user        = var.distro_ssh_user[var.distro]
@@ -48,12 +47,12 @@ resource "aws_instance" "prometheus" {
 }
 
 resource "aws_instance" "client" {
-  count                 = var.clients
-  ami                   = var.distro_ami[var.client_distro]
-  instance_type         = var.client_instance_type
-  key_name              = aws_key_pair.ssh.key_name
+  count                  = var.clients
+  ami                    = var.distro_ami[var.client_distro]
+  instance_type          = var.client_instance_type
+  key_name               = aws_key_pair.ssh.key_name
   vpc_security_group_ids = [aws_security_group.node_sec_group.id]
-  tags                  = local.instance_tags
+  tags                   = local.instance_tags
 
   connection {
     user        = var.distro_ssh_user[var.client_distro]
@@ -63,8 +62,8 @@ resource "aws_instance" "client" {
 }
 
 resource "aws_security_group" "node_sec_group" {
-  name = "${local.deployment_id}-node-sec-group"
-  tags = local.instance_tags
+  name        = "${local.deployment_id}-node-sec-group"
+  tags        = local.instance_tags
   description = "redpanda ports"
 
   # SSH access from anywhere
@@ -85,10 +84,10 @@ resource "aws_security_group" "node_sec_group" {
 
   # HTTP access to the RPC port
   ingress {
-    from_port   = 33145
-    to_port     = 33145
-    protocol    = "tcp"
-    self        = true
+    from_port = 33145
+    to_port   = 33145
+    protocol  = "tcp"
+    self      = true
   }
 
   # HTTP access to the Admin port
@@ -117,10 +116,10 @@ resource "aws_security_group" "node_sec_group" {
 
   # node exporter
   ingress {
-    from_port   = 9100
-    to_port     = 9100
-    protocol    = "tcp"
-    self        = true
+    from_port = 9100
+    to_port   = 9100
+    protocol  = "tcp"
+    self      = true
   }
 
   # outbound internet access
@@ -133,12 +132,11 @@ resource "aws_security_group" "node_sec_group" {
 }
 
 resource "aws_placement_group" "redpanda-pg" {
-  name                  = "redpanda-pg"
-  strategy              = "partition"
-  partition_count       = 3
-
-  tags = local.instance_tags
-  count = var.ha ? 1 : 0
+  name            = "redpanda-pg"
+  strategy        = "partition"
+  partition_count = 3
+  tags            = local.instance_tags
+  count           = var.ha ? 1 : 0
 }
 
 
@@ -150,15 +148,15 @@ resource "aws_key_pair" "ssh" {
 resource "local_file" "hosts_ini" {
   content = templatefile("${path.module}/../templates/hosts_ini.tpl",
     {
-      redpanda_public_ips   = aws_instance.redpanda.*.public_ip
-      redpanda_private_ips  = aws_instance.redpanda.*.private_ip
-      monitor_public_ip  = var.enable_monitoring ? aws_instance.prometheus[0].public_ip : ""
-      monitor_private_ip = var.enable_monitoring ? aws_instance.prometheus[0].private_ip : ""
-      ssh_user              = var.distro_ssh_user[var.distro]
-      enable_monitoring     = var.enable_monitoring
-      client_public_ips     = aws_instance.client.*.public_ip
-      client_private_ips    = aws_instance.client.*.private_ip
-      rack                  = aws_instance.redpanda.*.placement_partition_number
+      redpanda_public_ips  = aws_instance.redpanda.*.public_ip
+      redpanda_private_ips = aws_instance.redpanda.*.private_ip
+      monitor_public_ip    = var.enable_monitoring ? aws_instance.prometheus[0].public_ip : ""
+      monitor_private_ip   = var.enable_monitoring ? aws_instance.prometheus[0].private_ip : ""
+      ssh_user             = var.distro_ssh_user[var.distro]
+      enable_monitoring    = var.enable_monitoring
+      client_public_ips    = aws_instance.client.*.public_ip
+      client_private_ips   = aws_instance.client.*.private_ip
+      rack                 = aws_instance.redpanda.*.placement_partition_number
     }
   )
   filename = "${path.module}/../hosts.ini"

--- a/aws/readme.md
+++ b/aws/readme.md
@@ -50,6 +50,7 @@ No Modules.
 | distro\_ami | n/a | `map(string)` | <pre>{<br>  "amazon-linux-2": "ami-01ce4793a2f45922e",<br>  "debian-buster": "ami-0f7939d313699273c",<br>  "debian-stretch": "ami-072ad3956e05c814c",<br>  "fedora-31": "ami-0e82cc6ce8f393d4b",<br>  "fedora-32": "ami-020405ee5d5747724",<br>  "rhel-8": "ami-087c2c50437d0b80d",<br>  "ubuntu-bionic": "ami-0c1ab2d66f996cd4b",<br>  "ubuntu-focal": "ami-02c45ea799467b51b",<br> "ubuntu-hirsute": "ami-035649ffeb04ce758" <br>}</pre> | no |
 | distro\_ssh\_user | The default user used by the AWS AMIs | `map(string)` | <pre>{<br>  "amazon-linux-2": "ec2-user",<br>  "debian-buster": "admin",<br>  "debian-stretch": "admin",<br>  "fedora-31": "fedora",<br>  "fedora-32": "fedora",<br>  "rhel-8": "ec2-user",<br>  "ubuntu-\*": "ubuntu" <br>}</pre> | no |
 | enable\_monitoring | Setup a prometheus/grafana instance | `bool` | `true` | no |
+| ha | Enable high availability, which ensures each node is on a separate rack and the cluster is rack-aware | `bool` | `false` | no |
 | instance\_type | Default redpanda instance type to create | `string` | `"i3.2xlarge"` | no |
 | nodes | The number of nodes to deploy | `number` | `"3"` | no |
 | prometheus\_instance\_type | Instant type of the prometheus/grafana node | `string` | `"c5.2xlarge"` | no |

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -58,7 +58,7 @@ variable "public_key_path" {
 }
 
 variable "distro_ami" {
-  type = map(string)
+  type    = map(string)
   default = {
     # https://wiki.debian.org/Cloud/AmazonEC2Image/
     "debian-stretch" = "ami-072ad3956e05c814c"

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -9,6 +9,12 @@ variable "nodes" {
   default     = "3"
 }
 
+variable "ha" {
+  description = "Whether to use placement groups to create an HA topology"
+  type        = bool
+  default     = false
+}
+
 variable "distro" {
   description = "The default distribution to base the cluster on"
   default     = "ubuntu-focal"

--- a/templates/hosts_ini.tpl
+++ b/templates/hosts_ini.tpl
@@ -1,6 +1,6 @@
 [redpanda]
 %{ for i, ip in redpanda_public_ips ~}
-${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_private_ips[i]} id=${i}
+${ ip } ansible_user=${ ssh_user } ansible_become=True private_ip=${redpanda_private_ips[i]} id=${i} %{ if rack[i] != null }rack=${rack[i]}%{ endif }
 %{ endfor ~}
 %{ if enable_monitoring }
 


### PR DESCRIPTION
Tristan has an initial PR for implementing HA and rack awareness across AWS, GCP, and Azure. But during testing we ran into some issues in Azure that may require changes. At the same time a customer requires rack awareness in AWS.

This PR focuses on implementing this feature only in the AWS implementation. This will give us time to work through the changes needed for other cloud providers without impacting AWS customers. #82 is not closed with this PR as that ticket includes all cloud providers.

I've also included a small fix for prometheus so it properly starts (a dependency was missing from the Ubuntu distro).

In order to test, change this variable to true: https://github.com/redpanda-data/deployment-automation/blob/1a8f8f3fd799808b3acc3a06989d64abc91b6d9f/aws/vars.tf#L12-L16

Then run the following commands from the root directory:
```
cd aws
terraform init
terraform apply
cd ..
ansible-playbook --private-key `cat ~/.ssh/id_rsa.pub | awk '{print $2}'` -i hosts.ini -v ansible/playbooks/provision-node.yml -e advertise_public_ips=true -e grafana_admin_pass=password
```

fix #80