### PR TITLE
Correct issue with ansible tls install script and add features for variable EBS gp3 volume creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.sw?
 */**/.terraform
 */**/*.tfstate*
+*tfstate
 */**/*.lock*.hcl
 ansible/playbooks/grafana_dashboards/redpanda-grafana.json
 ansible/playbooks/tls/ca

--- a/ansible/playbooks/tls/install-certs.yml
+++ b/ansible/playbooks/tls/install-certs.yml
@@ -16,41 +16,41 @@
       group: redpanda
 
   - name: Configure via RPK
-    shell:
-      cmd: |
-        rpk redpanda config set redpanda "
+    shell: |
+      rpk redpanda config set redpanda.admin_api_tls '{
+        enabled: true,
+        require_client_auth: false,
+        key_file: /etc/redpanda/certs/node.key,
+        cert_file: /etc/redpanda/certs/node.crt,
+        truststore_file: /etc/redpanda/certs/truststore.pem
+      }' --format yaml
 
-          kafka_api:
-          - name: default
-            address: {{ hostvars[inventory_hostname]['private_ip'] }}
-            port: 9092
+      rpk redpanda config set redpanda.kafka_api_tls '{
+        enabled: true,
+        require_client_auth: false,
+        key_file: /etc/redpanda/certs/node.key,
+        cert_file: /etc/redpanda/certs/node.crt,
+        truststore_file: /etc/redpanda/certs/truststore.pem
+      }' --format yaml
 
-          advertised_kafka_api:
-          - name: default
-            address: {{ inventory_hostname }}
-            port: 9092
+      rpk redpanda config set redpanda.rpc_server_tls '{
+        enabled: true,
+        require_client_auth: false,
+        key_file: /etc/redpanda/certs/node.key,
+        cert_file: /etc/redpanda/certs/node.crt,
+        truststore_file: /etc/redpanda/certs/truststore.pem
+      }' --format yaml
 
-          kafka_api_tls:
-          - name: default
-            enabled: true
-            require_client_auth: false
-            cert_file: /etc/redpanda/certs/node.crt
-            key_file: /etc/redpanda/certs/node.key
-            truststore_file: /etc/redpanda/certs/truststore.pem
+      rpk redpanda config set 'rpk.admin_api' "
+        tls:
+          truststore_file: /etc/redpanda/certs/truststore.pem
+      " --format yaml
 
-          rpc_server_tls:
-            enabled: true
-            require_client_auth: false
-            cert_file: /etc/redpanda/certs/node.crt
-            key_file: /etc/redpanda/certs/node.key
-            truststore_file: /etc/redpanda/certs/truststore.pem
+      rpk redpanda config set 'rpk.kafka_api.tls' "
+          { truststore_file: /etc/redpanda/certs/truststore.pem }
+      " --format yaml
 
-        " --format yaml
-        rpk redpanda config set 'rpk.kafka_api' "
-            tls:
-              truststore_file: /etc/redpanda/certs/truststore.pem
-        " --format yaml
-        chown -R redpanda:redpanda /etc/redpanda
+      chown -R redpanda:redpanda /etc/redpanda
 
   - name: Restart redpanda
     systemd:

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -31,6 +31,22 @@ resource "aws_instance" "redpanda" {
   }
 }
 
+resource "aws_ebs_volume" "ebs_volume" {
+  count             = "${var.nodes * var.ec2_ebs_volume_count}"
+  availability_zone = "${element(aws_instance.redpanda.*.availability_zone, count.index)}"
+  size              = "${var.ec2_ebs_volume_size}"
+  type              = "${var.ec2_ebs_volume_type}"
+  iops              = "${var.ec2_ebs_volume_iops}"
+  throughput        = "${var.ec2_ebs_volume_throughput}"
+}
+
+resource "aws_volume_attachment" "volume_attachement" {
+  count       = "${var.nodes * var.ec2_ebs_volume_count}"
+  volume_id   = "${aws_ebs_volume.ebs_volume.*.id[count.index]}"
+  device_name = "${element(var.ec2_ebs_device_names, count.index)}"
+  instance_id = "${element(aws_instance.redpanda.*.id, count.index)}"
+}
+
 resource "aws_instance" "prometheus" {
   count                  = var.enable_monitoring ? 1 : 0
   ami                    = var.distro_ami[var.distro]
@@ -102,6 +118,14 @@ resource "aws_security_group" "node_sec_group" {
   ingress {
     from_port   = 3000
     to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # java client for omb
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -40,7 +40,7 @@ resource "aws_ebs_volume" "ebs_volume" {
   throughput        = "${var.ec2_ebs_volume_throughput}"
 }
 
-resource "aws_volume_attachment" "volume_attachement" {
+resource "aws_volume_attachment" "volume_attachment" {
   count       = "${var.nodes * var.ec2_ebs_volume_count}"
   volume_id   = "${aws_ebs_volume.ebs_volume.*.id[count.index]}"
   device_name = "${element(var.ec2_ebs_device_names, count.index)}"

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -25,9 +25,68 @@ variable "instance_type" {
   default     = "i3.2xlarge"
 }
 
+## It is important that device names do not get duplicated on hosts, in rare circumstances the choice of nodes * volumes can result in a factor that causes duplication. Modify this field so there is not a common factor.
+## Please pr a more elegant solution if you have one.
+variable "ec2_ebs_device_names" {
+  description = "Device names for EBS volumes"
+  default = [
+    "/dev/xvdba",
+    "/dev/xvdbb",
+    "/dev/xvdbc",
+    "/dev/xvdbd",
+    "/dev/xvdbe",
+    "/dev/xvdbf",
+    "/dev/xvdbg",
+    "/dev/xvdbh",
+    "/dev/xvdbi",
+    "/dev/xvdbj",
+    "/dev/xvdbk",
+    "/dev/xvdbl",
+    "/dev/xvdbm",
+    "/dev/xvdbn",
+    "/dev/xvdbo",
+    "/dev/xvdbp",
+    "/dev/xvdbq",
+    "/dev/xvdbr",
+    "/dev/xvdbs",
+    "/dev/xvdbt",
+    "/dev/xvdbu",
+    "/dev/xvdbv",
+    "/dev/xvdbw",
+    "/dev/xvdbx",
+    "/dev/xvdby",
+    "/dev/xvdbz"
+  ]
+}
+
+variable "ec2_ebs_volume_count" {
+  description = "Number of EBS volumes to attach to each Redpanda node"
+  default = 0
+}
+
+variable "ec2_ebs_volume_type" {
+  description = "EBS Volume Type (gp3 recommended for performance)"
+  default = "gp3"
+}
+
+variable "ec2_ebs_volume_iops" {
+  description = "IOPs for GP3 Volumes"
+  default = 16000
+}
+
+variable "ec2_ebs_volume_size" {
+  description = "Size of each EBS volume"
+  default = 100
+}
+
+variable "ec2_ebs_volume_throughput" {
+  description = "Throughput per volume in MiB"
+  default = 250
+}
+
 variable "client_instance_type" {
   description = "Default client instance type to create"
-  default     = "m5n.2xlarge"
+  default     = "m5n.2xlarge" 
 }
 
 variable "prometheus_instance_type" {

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -86,7 +86,7 @@ variable "ec2_ebs_volume_throughput" {
 
 variable "client_instance_type" {
   description = "Default client instance type to create"
-  default     = "m5n.2xlarge" 
+  default     = "m5n.2xlarge"
 }
 
 variable "prometheus_instance_type" {


### PR DESCRIPTION
This PR addresses a breaking issue with:

> ansible/playbooks/tls/install-certs.yml

Where it overwrites required configuration that was previously set with RPK config by the initial redpanda install scripts.

Non critical changes:
It additionally adds optional features for EBS volume creation to create gp3 or other types of EBS volumes, in multiples, and properly RAID-0 them. 