### PR TITLE
Introduce logic to support use of unstable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,19 @@ Before running these steps, verify that the `hosts.ini` file contains the correc
 Available Ansible variables:
 
 You can pass the following variables as `-e var=value`:
-* `advertise_public_ips=false|true`: Configure Redpanda to advertise the node's public IPs for client communication instead of private IPs. This allows for using the cluster from outside its subnet. **Note**: This is not recommended for production deployments, because it means that your nodes will be public. Use it for testing only. Default `false`
-* `grafana_admin_pass=<password_here>`: Configure Grafana's admin user's password
-* `ephemeral_disk`: Enable filesystem check for attached disk, useful when using attached disks in instances with ephemeral OS disks (i.e Azure L Series). This allows a filesystem repair at boot time and ensures that the drive is remounted automatically after a reboot. Default `false` 
 
-The Redpanda role defines a number of default values which can be overriden using `--extra-vars`. For a full list see the [role defaults file](ansible/playbooks/roles/redpanda_broker/defaults/main.yml).
+| Property                    | Default value              | Description                                                                                                                                                                                                                                                                                               |
+|-----------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `advertise_public_ips`      | `false`                    | Configure Redpanda to advertise the node's public IPs for client communication instead of private IPs. This allows for using the cluster from outside its subnet. **Note**: This is not recommended for production deployments, because it means that your nodes will be public. Use it for testing only. |
+| `grafana_admin_pass`        | enter_your_secure_password | Configure Grafana's admin user's password                                                                                                                                                                                                                                                                 |
+| `ephemeral_disk`            | `false`                    | Enable filesystem check for attached disk, useful when using attached disks in instances with ephemeral OS disks (i.e Azure L Series). This allows a filesystem repair at boot time and ensures that the drive is remounted automatically after a reboot.                                                 |
+| `redpanda_mode`             | production                 | [Enables hardware optimization](https://docs.redpanda.com/docs/platform/deployment/production-deployment/#set-redpanda-production-mode)                                                                                                                                                                   |                                                                                                                                                                  |                                                                                                            
+| `redpanda_admin_api_port`   | 9644                       |                                                                                                                                                                                                                                                                                                           |                                                                                                                                                                                                                                                                                                          |                                                                                                                  
+| `redpanda_kafka_port`       | 9092                       |                                                                                                                                                                                                                                                                                                           |                                                                                                                                                                  |                                                                                                                  
+| `redpanda_rpc_port`         | 33145                      |                                                                                                                                                                                                                                                                                                           |                                                                                                                                                                |                                                                                                                 
+| `redpanda_use_staging_repo` | `false`                    | Enables access to unstable builds                                                                                                                                                                                                                                                                         |                                                                                                                                                                                                                                                                        | False                                                                                                                                                                                                                                                                                                     
+| `redpanda_version`          | latest                     | For example 22.2.2-1 or 22.3.1~rc1-1. If this value is set then the package will be upgraded if the installed version is lower than what has been specified.                                                                                                                                              |
+| `redpanda_install_status`   | present                    | If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain                                                                                                                                            |
 
 You can also specify any available Redpanda configuration value (or set of values) by passing a JSON dictionary as an Ansible extra-var. These values will be spliced with the calculated configuration and only override those values that you specify.
 There are two sub-dictionaries that you can specify, `redpanda.cluster` and `redpanda.node`. Check the Redpanda docs for the available [Cluster configuration properties](https://docs.redpanda.com/docs/platform/reference/cluster-properties/) and [Node configuration properties](https://docs.redpanda.com/docs/platform/reference/node-properties/).
@@ -52,11 +60,13 @@ An example overriding specific properties would be as follows:
 
 ```commandline
 ansible-playbook ansible/playbooks/provision-node.yml -i hosts.ini  --extra-vars '{ "redpanda": 
-{"cluster":
-  { "auto_create_topics_enabled": "true"},
- "node":
-  { "developer_mode": "false"}
-  }
+ {"cluster":
+   { "auto_create_topics_enabled": "true"
+   },
+  "node":
+   { "developer_mode": "false"
+   }
+ }
 }'
 ```
 

--- a/ansible/playbooks/roles/redpanda_broker/defaults/main.yml
+++ b/ansible/playbooks/roles/redpanda_broker/defaults/main.yml
@@ -5,6 +5,13 @@ redpanda_admin_api_port: 9644
 redpanda_kafka_port: 9092
 redpanda_rpc_port: 33145
 
+redpanda_use_staging_repo: False
+redpanda_repo_debian: "{{ 'https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.deb.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.deb.sh' }}"
+redpanda_repo_redhat: "{{ 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.rpm.sh' if not redpanda_use_staging_repo|bool else 'https://dl.redpanda.com/E4xN1tVe3Xy60GTx/redpanda-unstable/setup.rpm.sh' }}"
+redpanda_repo_script: "{{ redpanda_repo_debian if ansible_os_family == 'Debian' else redpanda_repo_redhat }}"
+redpanda_version: latest # For example 22.2.2-1 or 22.3.1~rc1-1. If this value is set then the package will be upgraded if the installed version is lower than what has been specified.
+redpanda_install_status: present # If redpanda_version is set to latest, changing redpanda_install_status to latest will effect an upgrade, otherwise the currently installed version will remain
+
 redpanda_key_file: /etc/redpanda/certs/node.key
 redpanda_cert_file: /etc/redpanda/certs/node.crt
 redpanda_truststore_file: /etc/redpanda/certs/truststore.pem

--- a/ansible/playbooks/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -1,24 +1,25 @@
 ---
 - name: add the redpanda repo
   shell: |
-    curl -1sLf https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.deb.sh | sudo -E bash
+    curl -1sLf {{ redpanda_repo_script }} | sudo -E bash
   args:
     warn: no
-  when: ansible_os_family == 'Debian'
-
-- name: add the redpanda repo
-  shell: |
-    curl -1sLf https://packages.vectorized.io/sMIXnoa7DK12JW4A/redpanda/cfg/setup/bash.rpm.sh | sudo -E bash
-  args:
-    warn: no
-  when: ansible_os_family == 'RedHat'
 
 - name: install redpanda from repository
-  package:
+  apt:
     name:
-      - redpanda
-    state: present
+      - redpanda{{ '' if redpanda_version=='latest' else '=' + redpanda_version }}
+    state: "{{ redpanda_install_status }}"
     update_cache: yes
+  when: ansible_os_family == 'Debian'
+
+- name: install redpanda from repository
+  yum:
+    name:
+      - redpanda{{ '' if redpanda_version=='latest' else '-' + redpanda_version }}
+    state: "{{ redpanda_install_status }}"
+    update_cache: yes
+  when: ansible_os_family == 'RedHat'
 
 - name: set data dir file perms
   file:


### PR DESCRIPTION
Allow use of staging repo and specification of specific redpanda versions.
Updated README to include details of defaults