### PR TITLE
ansible: fix advertised apis

### DIFF
--- a/ansible/playbooks/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/ansible/playbooks/roles/redpanda_broker/templates/configs/defaults.j2
@@ -22,12 +22,6 @@ node:
     admin:
     - address: {{ hostvars[inventory_hostname].private_ip }}
       port: {{ redpanda_admin_api_port }}
-    advertised_rpc_api:
-      address: {{ hostvars[inventory_hostname].private_ip }}
-      port: {{ redpanda_rpc_port }}
-    advertised_kafka_api:
-    - address: {{ hostvars[inventory_hostname].advertised_ip }}
-      port: {{ redpanda_kafka_port }}
     seed_servers:
 {% for host in groups["redpanda"] %}
       - host:


### PR DESCRIPTION
We included two settings for both advertised_*_apis, one of which incorrectly pointed at the private IP rather than the advertised IP.