### PR TITLE
Remove erroneous list element from advertised_rpc_api

### DIFF
--- a/ansible/playbooks/roles/redpanda_broker/templates/configs/defaults.j2
+++ b/ansible/playbooks/roles/redpanda_broker/templates/configs/defaults.j2
@@ -10,7 +10,7 @@ node:
     - address: {{ hostvars[inventory_hostname].advertised_ip }}
       port: {{ redpanda_kafka_port }}
     advertised_rpc_api:
-    - address: {{ hostvars[inventory_hostname].advertised_ip }}
+      address: {{ hostvars[inventory_hostname].advertised_ip }}
       port: {{ redpanda_rpc_port }}
     data_directory: "{{ redpanda_data_directory }}"
     rpc_server:


### PR DESCRIPTION
Introduced by #98 which was a duplicate of the same value (one correct, one incorrect)