### PR TITLE
Bugfix/issue 103/shell cmd warn

### DIFF
--- a/ansible/playbooks/install-node-deps.yml
+++ b/ansible/playbooks/install-node-deps.yml
@@ -1,6 +1,6 @@
 - hosts: redpanda
   roles:
-  - cloudalchemy.node_exporter
+  - geerlingguy.node_exporter
 
   tasks:
   - name: fedora setup

--- a/ansible/playbooks/roles/redpanda_broker/tasks/install-redpanda.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/install-redpanda.yml
@@ -2,8 +2,6 @@
 - name: add the redpanda repo
   shell: |
     curl -1sLf {{ redpanda_repo_script }} | sudo -E bash
-  args:
-    warn: no
 
 - name: install redpanda from repository
   apt:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,4 @@
 - src: mrlesmithjr.mdadm
 - src: cloudalchemy.prometheus
 - src: cloudalchemy.grafana
-- src: cloudalchemy.node_exporter
+- src: geerlingguy.node_exporter


### PR DESCRIPTION
ansible 2.14+ doesn't support warn parameters for ansible.builtin.shell and causes playbook runs to fail.

This fixups the code where we use it explicitly. Complicating this issue, is the fact that the cloudalchemy.node_exporter module also has the same issue, but is no longer maintained. I've switched us over to geerlingguy's fork which is more recently updated and fixes the underlying problem. 