### PR TITLE
fix: unify public_key_path variable name

### DIFF
--- a/azure/cluster.tf
+++ b/azure/cluster.tf
@@ -25,7 +25,7 @@ resource "azurerm_linux_virtual_machine" "redpanda" {
   
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.public_key)
+    public_key = file(var.public_key_path)
   }
 
   source_image_reference {
@@ -87,7 +87,7 @@ resource "azurerm_linux_virtual_machine" "redpanda_client" {
 
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.public_key)
+    public_key = file(var.public_key_path)
   }
 
   source_image_reference {
@@ -123,7 +123,7 @@ resource "azurerm_linux_virtual_machine" "monitoring" {
 
   admin_ssh_key {
     username   = var.admin_username
-    public_key = file(var.public_key)
+    public_key = file(var.public_key_path)
   }
 
   source_image_reference {

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -27,7 +27,7 @@ output "ssh_user" {
 }
 
 output "public_key_path" {
-  value = var.public_key
+  value = var.public_key_path
 }
 
 resource "local_file" "hosts_ini" {

--- a/azure/vars.tf
+++ b/azure/vars.tf
@@ -84,7 +84,7 @@ variable "admin_username" {
   default     = "adminpanda"
 }
 
-variable "public_key" {
-  description = "Public Key file used for authentication"
+variable "public_key_path" {
+  description = "Public Key file used for authentication (must be RSA key on Azure)"
   default     = "~/.ssh/id_rsa.pub"
 }


### PR DESCRIPTION
our global variable names should be unified across clouds to simplify administration of the TF configurations for users, especially if they end up as multi-cloud implementations at some point. Azure had it different for no discernible reason.