### PR TITLE
Make git ignore _override.tf files for locally modifying tf vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ansible/playbooks/tls/certs
 hosts.ini
 .DS_Store
 .idea/*
+aws/_override.tf
+gcp/_override.tf
+azure/_override.tf


### PR DESCRIPTION
Let's make sure to never track these override files in the aws, gcp, and azure directories for folks having some standard variable overrides used for their dev environments. We don't want those sneaking in accidentally.