### PR TITLE
Implement more sophisticated serialization of the safe restart method…

### DIFF
--- a/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
@@ -3,11 +3,11 @@
 # only one node out of service at a time.
 #
 - name: Enable Maintenance Mode
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "rpk cluster maintenance enable {{ node_id }} --wait"
   when:
-   - restart_required
-   - inventory_hostname == cluster_host
+    - restart_required
+    - inventory_hostname == cluster_host
 
 # We need to (actually) generate the node config once the node is in MM, otherwise the `rpk cluster maintenance` command
 # will fail
@@ -17,21 +17,23 @@
     dest: "/etc/redpanda/redpanda.yaml"
     owner: redpanda
     group: redpanda
+    mode: 0755
   register: nodeconfig_result
   when:
     - is_initialized
     - inventory_hostname == cluster_host
 
-- name: Restart Process
-  ansible.builtin.shell:
-    cmd: "systemctl restart redpanda"
+- name: Restart Redpanda
+  ansible.builtin.systemd:
+    name: redpanda
+    state: restarted
   when:
-   - restart_required
-   - inventory_hostname == cluster_host
+    - restart_required
+    - inventory_hostname == cluster_host
 
 - name: Disable Maintenance Mode
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: "rpk cluster maintenance disable {{ node_id }}"
   when:
-   - restart_required
-   - inventory_hostname == cluster_host
+    - restart_required
+    - inventory_hostname == cluster_host

--- a/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
@@ -1,15 +1,3 @@
-
-- name: Generate Node config - post-bootstrap runs
-  ansible.builtin.template:
-    src: "redpanda.yml"
-    dest: "/etc/redpanda/redpanda.yaml"
-    owner: redpanda
-    group: redpanda
-  register: nodeconfig_result
-  when:
-    - is_initialized
-    - inventory_hostname == cluster_host
-
 # attempt to do a rolling, serial restart by putting each node into maintenance
 # mode, restarting, and putting it back into service. This is throttled to allow
 # only one node out of service at a time.
@@ -20,6 +8,19 @@
   when:
    - restart_required
    - inventory_hostname == cluster_host
+
+# We need to (actually) generate the node config once the node is in MM, otherwise the `rpk cluster maintenance` command
+# will fail
+- name: Generate Node config - post-bootstrap runs
+  ansible.builtin.template:
+    src: "redpanda.yml"
+    dest: "/etc/redpanda/redpanda.yaml"
+    owner: redpanda
+    group: redpanda
+  register: nodeconfig_result
+  when:
+    - is_initialized
+    - inventory_hostname == cluster_host
 
 - name: Restart Process
   ansible.builtin.shell:

--- a/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/safe-restart.yml
@@ -1,0 +1,36 @@
+
+- name: Generate Node config - post-bootstrap runs
+  ansible.builtin.template:
+    src: "redpanda.yml"
+    dest: "/etc/redpanda/redpanda.yaml"
+    owner: redpanda
+    group: redpanda
+  register: nodeconfig_result
+  when:
+    - is_initialized
+    - inventory_hostname == cluster_host
+
+# attempt to do a rolling, serial restart by putting each node into maintenance
+# mode, restarting, and putting it back into service. This is throttled to allow
+# only one node out of service at a time.
+#
+- name: Enable Maintenance Mode
+  ansible.builtin.shell:
+    cmd: "rpk cluster maintenance enable {{ node_id }} --wait"
+  when:
+   - restart_required
+   - inventory_hostname == cluster_host
+
+- name: Restart Process
+  ansible.builtin.shell:
+    cmd: "systemctl restart redpanda"
+  when:
+   - restart_required
+   - inventory_hostname == cluster_host
+
+- name: Disable Maintenance Mode
+  ansible.builtin.shell:
+    cmd: "rpk cluster maintenance disable {{ node_id }}"
+  when:
+   - restart_required
+   - inventory_hostname == cluster_host

--- a/ansible/playbooks/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -180,6 +180,7 @@
     dest: "/etc/redpanda/redpanda.yaml"
     owner: redpanda
     group: redpanda
+  check_mode: true
   register: nodeconfig_result
   when: is_initialized
 
@@ -208,12 +209,18 @@
   set_fact:
     restart_required: '("true" in restart_required_rc.stdout or (is_initialized and (nodeconfig_result.changed or "Removed" in package_result.results or "1 upgraded" in package_result.results))) and (restart_node | default("true") | bool)'
 
-# attempt to do a rolling, serial restart by putting each node into maintenance
-# mode, restarting, and putting it back into service. This is throttled to allow
-# only one node out of service at a time.
-#
-- name: Safe restart
-  ansible.builtin.shell:
-    cmd: "rpk cluster maintenance enable {{ node_id }} --wait && systemctl restart redpanda && rpk cluster maintenance disable {{ node_id }}"
-  when: restart_required
-  throttle: 1
+
+# serial: 1 would be the proper solution here, but that can only be set on play level
+# upstream issue: https://github.com/ansible/ansible/issues/12170
+# See this comment for an example of how this works:
+# https://github.com/ansible/ansible/issues/12170#issuecomment-358229274
+# Essentially we're looping through the hosts to run the tasks in safe-restart.yml.
+# Within safe-restart.yml we need to put inventory_hostname == cluster_host because other options
+# (delegate_to with run_once) meant that things like inventory_hostname get screwed up, and we don't get host facts.
+# It is known that the chosen method is O(n^2) but most people won't be deploying 100s of nodes via this route.
+
+- name: Safe Restart
+  include_tasks: safe-restart.yml
+  with_items: "{{ ansible_play_hosts }}"
+  loop_control:
+    loop_var: cluster_host

--- a/ansible/playbooks/roles/redpanda_broker/tasks/start-redpanda.yml
+++ b/ansible/playbooks/roles/redpanda_broker/tasks/start-redpanda.yml
@@ -159,7 +159,7 @@
 # this instance of node config generation only runs after a cluster has been
 # initialized. This is used to update configurations post-cluster setup when
 # the user adds new configurations. For example, this would fire off after the
-# user adds TLS support to the cluster. 
+# user adds TLS support to the cluster.
 #
 # Ideally, there's only one task that runs node configuration and we trigger it
 # to re-run as appropriate. We do it this way right now mostly because of task
@@ -185,9 +185,9 @@
   when: is_initialized
 
 # Determine if a restart is necessary based on the following logic
-# 
+#
 # set restart_node to false in your Ansible variables if you want to manage
-# restarts on your own. 
+# restarts on your own.
 #
 #   (
 #     The rpk cluster config status says that this node requires restarting


### PR DESCRIPTION
… that allows us to bring in the modification of /etc/redpanda/redpanda.yaml into the part after we've put the node into maintenance mode.

Fixes #115 