### PR TITLE
Added optional vpc_id and subnet_id to allow deploying in a specific vpc

### DIFF
--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -226,9 +226,21 @@ variable "private_key_path" {
   default     = null
 }
 
+variable "subnet_id" {
+  type        = string
+  description = "The ID ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of key value pairs passed through to AWS tags on resources"
   nullable    = true
   default     = null
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC to deploy. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided."
+  default     = ""
 }


### PR DESCRIPTION
Added variables for subnet_id and vpc_id that are defaulted to empty string. An attempt will be made to fetch the default vpc if a vpc_id is not specified. If no subnet_id is specified, it defaults to a subnet in the default vpc.
This allows users to choose a vpc and subnet for the deployment. An error is thrown if the subnet is not in the the vpc.