### PR TITLE
Making the terraform more module friendly

### DIFF
--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -168,7 +168,7 @@ resource "aws_security_group" "node_sec_group" {
   name        = "${local.deployment_id}-node-sec-group"
   tags        = local.merged_tags
   description = "redpanda ports"
-  vpc_id      = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default.id
+  vpc_id      = var.vpc_id
 
   # SSH access from anywhere
   ingress {
@@ -294,9 +294,4 @@ data "aws_caller_identity" "current" {}
 
 data "aws_arn" "caller_arn" {
   arn = data.aws_caller_identity.current.arn
-}
-
-# retrieve the default vpc ID
-data "aws_vpc" "default" {
-  default = true
 }

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -76,7 +76,7 @@ resource "aws_instance" "redpanda" {
   instance_type              = var.instance_type
   key_name                   = aws_key_pair.ssh.key_name
   iam_instance_profile       = var.tiered_storage_enabled ? aws_iam_instance_profile.redpanda[0].name : null
-  vpc_security_group_ids     = [aws_security_group.node_sec_group.id]
+  vpc_security_group_ids     = concat([aws_security_group.node_sec_group.id], var.security_groups_redpanda)
   placement_group            = var.ha ? aws_placement_group.redpanda-pg[0].id : null
   placement_partition_number = var.ha ? (count.index % aws_placement_group.redpanda-pg[0].partition_count) + 1 : null
   subnet_id                  = var.subnet_id   
@@ -120,7 +120,7 @@ resource "aws_instance" "prometheus" {
   instance_type          = var.prometheus_instance_type
   key_name               = aws_key_pair.ssh.key_name
   subnet_id              = var.subnet_id   
-  vpc_security_group_ids = [aws_security_group.node_sec_group.id]
+  vpc_security_group_ids = concat([aws_security_group.node_sec_group.id], var.security_groups_prometheus)
   tags                   = merge(
     local.merged_tags,
     {
@@ -145,7 +145,7 @@ resource "aws_instance" "client" {
   instance_type          = var.client_instance_type
   key_name               = aws_key_pair.ssh.key_name
   subnet_id              = var.subnet_id   
-  vpc_security_group_ids = [aws_security_group.node_sec_group.id]
+  vpc_security_group_ids = concat([aws_security_group.node_sec_group.id], var.security_groups_client)
   tags                   = merge(
     local.merged_tags,
     {
@@ -172,11 +172,11 @@ resource "aws_security_group" "node_sec_group" {
 
   # SSH access from anywhere
   ingress {
-    description = "Allow anywhere inbound to ssh"
+    description = "Allow inbound to ssh"
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.ssh_security_rule_cidr
   }
 
   # HTTP access from anywhere to port 9092

--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -287,6 +287,18 @@ resource "local_file" "hosts_ini" {
   filename = "${path.module}/../hosts.ini"
 }
 
+locals {
+  node_details = [
+    for index,instance in aws_instance.redpanda:
+     {
+      "instance_id": instance.id
+      "public_ip":  instance.public_ip
+      "private_ip": instance.private_ip
+      "name": "${var.deployment_prefix}-node-${index}"
+     }
+  ]
+}
+
 # we extract the IAM username by getting the caller identity as an ARN
 # then extracting the resource protion, which gives something like 
 # user/travis.downs, and finally we strip the user/ part to use as a tag

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,7 +1,7 @@
 output "redpanda" {
   value = {
     for instance in aws_instance.redpanda :
-    instance.public_ip => instance.private_ip
+    instance.public_ip => instance.private_ip...
   }
 }
 

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -5,17 +5,38 @@ output "redpanda" {
   }
 }
 
+output "redpanda_id" {
+  value = {
+    for instance in aws_instance.redpanda :
+    "instance_id" => instance.id...
+  }
+}
+
 output "prometheus" {
   value = {
     for instance in aws_instance.prometheus :
-    instance.public_ip => instance.private_ip
+    instance.public_ip => instance.private_ip...
+  }
+}
+
+output "prometheus_id" {
+  value = {
+    for instance in aws_instance.prometheus :
+    "instance_id" => instance.id...
   }
 }
 
 output "client" {
   value = {
     for instance in aws_instance.client :
-    instance.public_ip => instance.private_ip
+    instance.public_ip => instance.private_ip...
+  }
+}
+
+output "client_id" {
+  value = {
+    for instance in aws_instance.client :
+    "instance_id" => instance.id...
   }
 }
 

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -47,3 +47,7 @@ output "ssh_user" {
 output "public_key_path" {
   value = var.public_key_path
 }
+
+output "node_details" {
+  value = local.node_details
+}

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -226,9 +226,21 @@ variable "private_key_path" {
   default     = null
 }
 
+variable "subnet_id" {
+  type        = string
+  description = "The ID ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map of key value pairs passed through to AWS tags on resources"
   nullable    = true
   default     = null
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC to deploy. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided."
+  default     = ""
 }

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -241,6 +241,6 @@ variable "tags" {
 
 variable "vpc_id" {
   type        = string
-  description = "The ID of the VPC to deploy. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided."
+  description = "The ID of the VPC to deploy the instances. If an ID is an empty string, the default VPC is used. If provided, the subnet_id must also be provided."
   default     = ""
 }

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -226,6 +226,30 @@ variable "private_key_path" {
   default     = null
 }
 
+variable "security_groups_client" {
+  type        = list(string)
+  description = "Any additional security groups to attach to the client nodes"
+  default     = []
+}
+
+variable "security_groups_prometheus" {
+  type        = list(string)
+  description = "Any additional security groups to attach to the prometheus nodes"
+  default     = []
+}
+
+variable "security_groups_redpanda" {
+  type        = list(string)
+  description = "Any additional security groups to attach to the Redpanda nodes"
+  default     = []
+}
+
+variable "ssh_security_rule_cidr" {
+  type        = list(string)
+  description = "List of CIDRs for the security group's SSH ingress rule. Defaults to 0.0.0.0/0 if not specified."
+  default     = [ "0.0.0.0/0" ]
+}
+
 variable "subnet_id" {
   type        = string
   description = "The ID ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"


### PR DESCRIPTION
Added vpc_id and subnet_id inputs to allow specifying the VPC to deploy instances.
Added sg inputs for the instances to allow adding any existing or other generated sg to the instances
Added more outputs for referencing as a module.
Added the ... to outputs that potentially returned multiple items because I was getting errors.