### PR TITLE
add consume from topic

### DIFF
--- a/.buildkite/scripts/testcluster.sh
+++ b/.buildkite/scripts/testcluster.sh
@@ -50,3 +50,6 @@ echo "creating topic"
 
 echo "producing to topic"
 echo test | "${PATH_TO_RPK_FILE}" topic produce testtopic --brokers "$REDPANDA_BROKERS" --tls-truststore "$PATH_TO_CA_CRT" -v || exit 1
+
+echo "consuming from topic"
+"${PATH_TO_RPK_FILE}" topic produce testtopic --brokers "$REDPANDA_BROKERS" --tls-truststore "$PATH_TO_CA_CRT" -v -o :end || exit 1


### PR DESCRIPTION
without -o :end the topic consumption will hang. hopefully this will cause it to simply dump the last message and exit immediately (if i got it right)