### PR TITLE
Update tiered_storage.j2 to use correct cloud_storage_region

### DIFF
--- a/ansible/playbooks/roles/redpanda_broker/templates/configs/tiered_storage.j2
+++ b/ansible/playbooks/roles/redpanda_broker/templates/configs/tiered_storage.j2
@@ -3,8 +3,9 @@ cluster:
   cloud_storage_bucket: {{ tiered_storage_bucket_name if tiered_storage_bucket_name is defined }}
   cloud_storage_enable_remote_read: true
   cloud_storage_enable_remote_write: true
-  cloud_storage_region: {{ aws_region if aws_region is defined }}
+  cloud_storage_region: {{ cloud_storage_region if cloud_storage_region is defined }}
   cloud_storage_secret_key: THISVALUENOTUSED
   cloud_storage_credentials_source: aws_instance_metadata
   # cloud_storage_enabled must be after other cloud_storage parameters
   cloud_storage_enabled: {{ true if tiered_storage_bucket_name is defined and tiered_storage_bucket_name|d('')|length > 0 else false }}
+


### PR DESCRIPTION
This seems to be a problem introduced when handling a merge conflict (or possibly with the tiered storage PR itself). The variable was still set as the older (now renamed) `aws_region`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204218351695001