### PR TITLE
add playbook install deps for node exporter

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -182,9 +182,8 @@ tasks:
       - mkdir -p {{.ARTIFACT_DIR}}/tmp
       - curl -L https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip -o {{.ARTIFACT_DIR}}/tmp/rpk-linux-amd64.zip
       - mkdir -p {{.ARTIFACT_DIR}}/bin
-      - unzip {{.ARTIFACT_DIR}}/tmp/rpk-linux-amd64.zip -d {{.ARTIFACT_DIR}}/bin/
+      - unzip -o {{.ARTIFACT_DIR}}/tmp/rpk-linux-amd64.zip -d {{.ARTIFACT_DIR}}/bin/
       - chmod 755 {{.ARTIFACT_DIR}}/bin/rpk
-      - rm -f {{.ARTIFACT_DIR}}/tmp/rpk-linux-amd64.zip
     status:
       - test -f '{{.ARTIFACT_DIR}}/bin/rpk || command -v rpk'
 

--- a/ansible/deploy-prometheus-grafana.yml
+++ b/ansible/deploy-prometheus-grafana.yml
@@ -16,6 +16,12 @@
         dest: '{{ playbook_dir }}/grafana_dashboards/redpanda-grafana.json'
         flat: true
 
+- hosts: redpanda
+  tasks:
+    - name: Node dependencies - include geerlingguy nodeexporter
+      ansible.builtin.include_role:
+        name: geerlingguy.node_exporter
+
 - hosts: monitor
   tasks:
     - name: install deps


### PR DESCRIPTION
Install deps for node exports when standing up prom, not just as part of the standard cluster build.

Also fix a minor but annoying issue with install-rpk task asking for permission to overwrite

Tested in AWS by 
* standing up cluster
* applying basic cluster playbook (soon to be resolved issue with rpk not offering a way to pass truststore to admin for metrics stuff means this won't work with TLS right now)
* applying prometheus playbook
* going to prom page and running various queries successfully