### PR TITLE
Minor additions to AWS TF

### DIFF
--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -2,6 +2,7 @@ resource "aws_s3_bucket" "tiered_storage" {
   count  = var.tiered_storage_enabled ? 1 : 0
   bucket = local.tiered_storage_bucket_name
   tags   = local.instance_tags
+  force_destroy = var.allow_force_destroy
 }
 
 resource "aws_s3_bucket_acl" "tiered_storage" {

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -258,7 +258,7 @@ variable "ssh_security_rule_cidr" {
 
 variable "subnet_id" {
   type        = string
-  description = "The ID ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
+  description = "The ID of the subnet where the EC2 instances will be deployed. An empty string will deploy to the default VPC. If provided, it must be in the same VPC as vpc_id"
   default     = ""
 }
 
@@ -279,4 +279,18 @@ variable "cloud_provider" {
   type        = string
   description = "the short, lower case form of the cloud provider"
   default     = "aws"
+}
+
+# allow_force_destroy is only intended for demos and CI testing and to support decommissioning a cluster entirely
+# enabling it will result in loss of any data or topic info stored in the bucket
+variable "allow_force_destroy" {
+  default     = false
+  type        = bool
+  description = "DANGER: Enabling this option will delete your data in Tiered Storage when terraform destroy is run. Enable this only after careful consideration of the data loss consequences."
+}
+
+variable "associate_public_ip_addr" {
+  default = false
+  type = bool
+  description = "Allows enabling public ips when using a custom VPC rather than the default"
 }


### PR DESCRIPTION
Associate public IP fixes an issue some customers had with using a custom VPC while also wanting to use public IPs.

allow_force_destroy allows destroying a bucket even with data in it. Useful for testing and demos.

Everything else is minor text/syntax cleanup.