### PR TITLE
Put needed vars in playbook

### DIFF
--- a/ansible/provision-node.yml
+++ b/ansible/provision-node.yml
@@ -6,6 +6,7 @@
   hosts: redpanda
   vars:
     advertise_public_ips: true
+    redpanda_version: latest
   tasks:
     - name: Install and start redpanda
       ansible.builtin.include_role:

--- a/ansible/provision-tls-cluster.yml
+++ b/ansible/provision-tls-cluster.yml
@@ -17,6 +17,9 @@
     advertise_public_ips: true
     create_demo_certs: true
     handle_cert_install: true
+    redpanda_version: latest
+    ca_cert_file: "tls/ca/ca.crt"
+    node_cert_file: "tls/certs/{{ansible_hostname}}/node.crt"
   tasks:
     - name: Install and configure CA certs for running tls
       ansible.builtin.include_role:


### PR DESCRIPTION
Since we're removing these as defaults from the role they should be provided in the playbook. It might be sensible to set version to blank to ensure the user MUST select it.

related to https://github.com/redpanda-data/redpanda-ansible-collection/pull/8