### PR TITLE
add missing resourced needed for ListBucket

### DIFF
--- a/aws/cluster.tf
+++ b/aws/cluster.tf
@@ -31,7 +31,8 @@ resource "aws_iam_policy" "redpanda" {
           "s3-object-lambda:*",
         ],
         "Resource" : [
-          "arn:aws:s3:::${local.tiered_storage_bucket_name}/*"
+          "arn:aws:s3:::${local.tiered_storage_bucket_name}/*",
+          "arn:aws:s3:::${local.tiered_storage_bucket_name}"
         ]
       },
     ]


### PR DESCRIPTION
the policy we create on behalf of the user for allowing the instance to access the s3 bucket appears to be missing a resource required by Redpanda needed for ListBucket. 

See internal discussion at https://redpandadata.slack.com/archives/C02BDN76HUK/p1683670439226129