### PR TITLE
add support for fedora testing + fix bugs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,9 +2,9 @@ agents:
   queue: "k8s-builders"
 
 steps:
-  - label: test tls cluster standup
-    key: tls-up
-    command: .buildkite/scripts/standup-tls.sh
+  - label: test tls cluster standup ubuntu
+    key: tls-up-ubuntu
+    command: .buildkite/scripts/standup-tls.sh --prefix=rp-tls-ub --distro=ubuntu-focal
     plugins:
       - docker#v5.4.0:
           image: glrp/atgt:latest
@@ -12,9 +12,29 @@ steps:
             - DA_AWS_ACCESS_KEY_ID
             - DA_AWS_SECRET_ACCESS_KEY
             - AWS_DEFAULT_REGION
-  - label: test tiered-storage-up cluster standup
-    key: tiered-up
-    command: .buildkite/scripts/standup-tiered-storage.sh
+  - label: test tiered-storage-up cluster standup ubuntu
+    key: tiered-up-ubuntu
+    command: .buildkite/scripts/standup-tiered-storage.sh --prefix=rp-tier-ub --distro=ubuntu-focal
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+  - label: test tls cluster standup fedora
+    key: tls-up-fedora
+    command: .buildkite/scripts/standup-tls.sh --prefix=rp-tls-fd --distro=Fedora-Cloud-Base-36
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
+  - label: test tiered-storage-up cluster standup fedora
+    key: tiered-up-fedora
+    command: .buildkite/scripts/standup-tiered-storage.sh --prefix=rp-tier-fd --distro=Fedora-Cloud-Base-36
     plugins:
       - docker#v5.4.0:
           image: glrp/atgt:latest

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
             - AWS_DEFAULT_REGION
   - label: test tls cluster standup fedora
     key: tls-up-fedora
-    command: .buildkite/scripts/standup-tls.sh --prefix=rp-tls-fd --distro=Fedora-Cloud-Base-36
+    command: .buildkite/scripts/standup-tls.sh --prefix=rp-tls-fd --distro=Fedora-Cloud-Base-34
     plugins:
       - docker#v5.4.0:
           image: glrp/atgt:latest
@@ -34,7 +34,7 @@ steps:
             - AWS_DEFAULT_REGION
   - label: test tiered-storage-up cluster standup fedora
     key: tiered-up-fedora
-    command: .buildkite/scripts/standup-tiered-storage.sh --prefix=rp-tier-fd --distro=Fedora-Cloud-Base-36
+    command: .buildkite/scripts/standup-tiered-storage.sh --prefix=rp-tier-fd --distro=Fedora-Cloud-Base-34
     plugins:
       - docker#v5.4.0:
           image: glrp/atgt:latest

--- a/.buildkite/scripts/standup-tiered-storage.sh
+++ b/.buildkite/scripts/standup-tiered-storage.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+
+# Parse the named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix=*)
+      PREFIX="${1#*=}"
+      ;;
+    --distro=*)
+      DISTRO="${1#*=}"
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      exit 1
+  esac
+  shift
+done
+
+if [ -z "$PREFIX" ] || [ -z "$DISTRO" ]; then
+  echo ""
+  echo "ERROR: invalid input"
+  echo ""
+  echo "Usage: ./standup-tiered-storage.sh.sh --prefix=PREFIX --distro=DISTRO"
+  echo "prefix  : a short prefix for identifying resources"
+  echo "distro  : name of an image distro, must match the lookup in vars.tf"
+  exit 1
+fi
+
 cleanup() {
   exit_code=$?
   echo "trapped exit, cleaning up"
@@ -10,12 +37,13 @@ trap cleanup EXIT INT TERM
 
 echo "beginning tiered storage cluster testing"
 task keygen
+error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in keygen"
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tiered TIERED_STORAGE_ENABLED=true task apply -- -var='tags={
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO TIERED_STORAGE_ENABLED=true task apply -- -var='tags={
   "VantaOwner" : "devex@redpanda.com"
   "VantaNonProd" : "true"
   "VantaDescription" : "cicd-instance-for-devex"
@@ -30,21 +58,21 @@ if [ $error_code -ne 0 ]; then
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tiered task create-tiered-storage-cluster
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task create-tiered-storage-cluster
 error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in ansible standup"
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tiered task test-tiered-storage-cluster
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task test-tiered-storage-cluster
 error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in test-tls-cluster"
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tiered TIERED_STORAGE_ENABLED=true  task destroy -- '-var=tags={
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO TIERED_STORAGE_ENABLED=true  task destroy -- '-var=tags={
   "VantaOwner" : "devex@redpanda.com"
   "VantaNonProd" : "true"
   "VantaDescription" : "cicd-instance-for-devex"

--- a/.buildkite/scripts/standup-tls.sh
+++ b/.buildkite/scripts/standup-tls.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
 
+# Parse the named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix=*)
+      PREFIX="${1#*=}"
+      ;;
+    --distro=*)
+      DISTRO="${1#*=}"
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      exit 1
+  esac
+  shift
+done
+
+if [ -z "$PREFIX" ] || [ -z "$DISTRO" ]; then
+  echo ""
+  echo "ERROR: invalid input"
+  echo ""
+  echo "Usage: ./standup-tiered-storage.sh.sh --prefix=PREFIX --distro=DISTRO"
+  echo "prefix  : a short prefix for identifying resources"
+  echo "distro  : name of an image distro, must match the lookup in vars.tf"
+  exit 1
+fi
+
+
 cleanup() {
   exit_code=$?
   echo "trapped exit, cleaning up"
@@ -10,12 +37,13 @@ trap cleanup EXIT INT TERM
 
 echo "beginning tls cluster testing"
 task keygen
+error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in keygen"
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tls task apply -- -var='tags={
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task apply -- -var='tags={
   "VantaOwner" : "devex@redpanda.com"
   "VantaNonProd" : "true"
   "VantaDescription" : "cicd-instance-for-devex"
@@ -30,7 +58,7 @@ if [ $error_code -ne 0 ]; then
   exit 1
 fi
 
-DEPLOYMENT_ID=rp-devex-tls task create-tls-cluster
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task create-tls-cluster
 error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in ansible standup"
@@ -38,13 +66,13 @@ if [ $error_code -ne 0 ]; then
 fi
 
 
-DEPLOYMENT_ID=rp-devex-tls task test-tls-cluster
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task test-tls-cluster
 error_code=$?
 if [ $error_code -ne 0 ]; then
   echo "error in test-tls-cluster"
   exit 1
 fi
-DEPLOYMENT_ID=rp-devex-tls task destroy -- '-var=tags={
+DEPLOYMENT_ID=$PREFIX DISTRO=$DISTRO task destroy -- '-var=tags={
   "VantaOwner" : "devex@redpanda.com"
   "VantaNonProd" : "true"
   "VantaDescription" : "cicd-instance-for-devex"

--- a/Dockerfile_FEDORA
+++ b/Dockerfile_FEDORA
@@ -1,0 +1,30 @@
+FROM fedora:36
+
+ENV DA_AWS_ACCESS_KEY_ID="default"
+ENV DA_AWS_SECRET_ACCESS_KEY="default"
+ENV AWS_DEFAULT_REGION="default"
+
+# Install required packages
+RUN dnf -y update \
+    && dnf install -y unzip wget glibc curl vim git ansible jq openssl \
+    && rm -rf /var/cache/dnf/*
+
+# Install Terraform
+RUN wget https://releases.hashicorp.com/terraform/1.4.5/terraform_1.4.5_linux_amd64.zip \
+    && unzip terraform_1.4.5_linux_amd64.zip -d /usr/local/bin \
+    && rm terraform_1.4.5_linux_amd64.zip
+
+# Install aws cli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" \
+&& unzip awscliv2.zip \
+&& ./aws/install
+
+# Install task
+RUN curl -sSLf "https://github.com/go-task/task/releases/download/v3.21.0/task_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin
+
+## uncomment for use as a local client
+#RUN mkdir -p /app
+#COPY . /app
+
+# Set the default command to run when the container starts
+CMD ["/bin/bash"]

--- a/Dockerfile_UBUNTU
+++ b/Dockerfile_UBUNTU
@@ -5,7 +5,7 @@ ENV DA_AWS_ACCESS_KEY_ID="default"
 ENV DA_AWS_SECRET_ACCESS_KEY="default"
 ENV AWS_DEFAULT_REGION="default"
 
-# Install the good stuff
+# Install required packages
 RUN apt-get update \
     && apt install unzip -y \
     && apt install wget -y \
@@ -20,9 +20,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Terraform
-RUN wget https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip \
-    && unzip terraform_1.3.7_linux_amd64.zip -d /usr/local/bin \
-    && rm terraform_1.3.7_linux_amd64.zip
+RUN wget https://releases.hashicorp.com/terraform/1.4.5/terraform_1.4.5_linux_amd64.zip \
+    && unzip terraform_1.4.5_linux_amd64.zip -d /usr/local/bin \
+    && rm terraform_1.4.5_linux_amd64.zip
 
 # Install task
 RUN curl -sSLf "https://github.com/go-task/task/releases/download/v3.21.0/task_linux_amd64.tar.gz" | tar -xz -C /usr/local/bin

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -19,6 +19,7 @@ vars:
   ALLOW_FORCE_DESTROY: '{{ .ALLOW_FORCE_DESTROY | default "true"}}'
   VPC_ID: '{{ .VPC_ID | default "" }}'
   BUCKET_NAME: '{{ .DEPLOYMENT_ID | replace "_" "-"}}-bucket'
+  DISTRO: '{{ .DISTRO | default "" }}'
 
   # ansible stuff
   ANSIBLE_VERSION: '2.11.12'
@@ -27,7 +28,6 @@ vars:
   ANSIBLE_INVENTORY: '{{.ARTIFACT_DIR}}/hosts_{{.CLOUD_PROVIDER}}_{{.DEPLOYMENT_ID}}.ini'
   ANSIBLE_COLLECTIONS_PATHS: '{{ .ARTIFACT_DIR }}/collections'
   ANSIBLE_ROLES_PATH: '{{.ARTIFACT_DIR}}:{{.ROLES_DIR}}:{{.ANSIBLE_COLLECTIONS_PATHS}}:{{.ANSIBLE_COLLECTIONS_PATHS}}/ansible_collections/redpanda/cluster/roles'
-  ANSIBLE_COLLECTION_INSTALL: '{{ default "redpanda.cluster" .ANSIBLE_COLLECTION_INSTALL }}'
 
   TF_SSH_USER_VAR:
     sh: |
@@ -102,6 +102,7 @@ tasks:
           -var='tiered_storage_enabled={{.TIERED_STORAGE_ENABLED}}' \
           -var='allow_force_destroy={{.ALLOW_FORCE_DESTROY}}' \
           -var='vpc_id={{.VPC_ID}}' \
+          -var='distro={{.DISTRO}}' \
           {{.CLI_ARGS}}
 
   destroy:
@@ -126,6 +127,7 @@ tasks:
         -var='tiered_storage_enabled={{.TIERED_STORAGE_ENABLED}}' \
         -var='allow_force_destroy={{.ALLOW_FORCE_DESTROY}}' \
         -var='vpc_id={{.VPC_ID}}' \
+        -var='distro={{.DISTRO}}' \
         {{.CLI_ARGS}}
 
   install-role-requirements:
@@ -133,11 +135,12 @@ tasks:
     env:
       ANSIBLE_ROLES_PATH: '{{.ROLES_DIR}}'
       ANSIBLE_COLLECTION_INSTALL: '{{ .ANSIBLE_COLLECTION_INSTALL }}'
+      ANSIBLE_COLLECTIONS_PATHS: '{{ .ANSIBLE_COLLECTIONS_PATHS }}'
     run: once
     cmds:
       - mkdir -p "$ANSIBLE_ROLES_PATH"
-      - ansible-galaxy install -r "requirements.yml"
-      - ansible-galaxy collection install {{ .ANSIBLE_COLLECTION_INSTALL }} -p {{ .ANSIBLE_COLLECTIONS_PATHS }}
+      - ansible-galaxy install -r requirements.yml
+      - ansible-galaxy collection install -r requirements.yml -p {{ .ANSIBLE_COLLECTIONS_PATHS }}
 
   basic:
     desc: run an ansible playbook to create a basic private cluster

--- a/aws/vars.tf
+++ b/aws/vars.tf
@@ -143,19 +143,19 @@ variable "prometheus_instance_type" {
 
 variable "cluster_ami" {
   type        = string
-  description = "AMI for Redpanda broker nodes (if not set, will select based on the client_distro variable"
+  description = "AMI for Redpanda broker nodes (if not set, will select based on the distro variable"
   default     = null
 }
 
 variable "prometheus_ami" {
   type        = string
-  description = "AMI for prometheus nodes (if not set, will select based on the client_distro variable"
+  description = "AMI for prometheus nodes (if not set, will select based on the distro variable"
   default     = null
 }
 
 variable "client_ami" {
   type        = string
-  description = "AMI for Redpanda client nodes (if not set, will select based on the client_distro variable"
+  description = "AMI for Redpanda client nodes (if not set, will select based on the distro variable"
   default     = null
 }
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,7 @@ collections:
   - name: community.general
   - name: redpanda.cluster
     type: galaxy
+  - name: ansible.posix
 
 roles:
   - src: mrlesmithjr.mdadm


### PR DESCRIPTION
This is a minor testing improvement to support ongoing airgap work in [RAC](https://github.com/redpanda-data/redpanda-ansible-collection)

added ansible.posix to required collections
added distro and prefix as settable values to the pipeline scripts 
corrected taskfile collection install
fixed vars comments incorrectly referring to var.client_distro 
added fedora testing for tiered/tls to pipeline
fixed an uncaught error code for keygen