### PR TITLE
Align Azure availability zone parameter name

### DIFF
--- a/azure/cluster.tf
+++ b/azure/cluster.tf
@@ -1,5 +1,5 @@
 locals {
-  zone_count = try(length(var.availability_zones), 0)
+  zone_count = try(length(var.availability_zone), 0)
   multi_az = local.zone_count > 1
   single_az = local.zone_count <= 1
   use_availability_sets = var.ha && local.single_az
@@ -20,7 +20,7 @@ resource "azurerm_linux_virtual_machine" "redpanda" {
   proximity_placement_group_id = local.single_az ? azurerm_proximity_placement_group.redpanda.0.id : null
   virtual_machine_scale_set_id = local.use_vmss ? azurerm_orchestrated_virtual_machine_scale_set.redpanda.0.id : null
   platform_fault_domain        = local.multi_az || local.use_availability_sets ? null : count.index % 3
-  zone                         = local.use_availability_sets ? null : try(var.availability_zones[count.index % length(var.availability_zones)], null)
+  zone                         = local.use_availability_sets ? null : try(var.availability_zone[count.index % length(var.availability_zone)], null)
   size                         = var.vm_sku
   admin_username               = var.admin_username
   network_interface_ids        = ["${element(azurerm_network_interface.redpanda.*.id, count.index)}"]
@@ -86,7 +86,7 @@ resource "azurerm_linux_virtual_machine" "redpanda_client" {
   size                         = var.client_vm_sku
   admin_username               = var.admin_username
   network_interface_ids        = ["${element(azurerm_network_interface.redpanda_client.*.id, count.index)}"]
-  zone                         = try(var.availability_zones[count.index % length(var.availability_zones)], null)
+  zone                         = try(var.availability_zone[count.index % length(var.availability_zone)], null)
 
   os_disk {
     storage_account_type = "Standard_LRS"

--- a/azure/network.tf
+++ b/azure/network.tf
@@ -45,7 +45,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "redpanda" {
   proximity_placement_group_id = local.single_az ? azurerm_proximity_placement_group.redpanda[0].id : null
   count                        = local.use_vmss ? 1 : 0
   zone_balance                 = local.multi_az ? true : false
-  zones                        = local.multi_az ? var.availability_zones : null
+  zones                        = local.multi_az ? var.availability_zone : null
 
   tags = {
     deployment_id = local.deployment_id
@@ -212,7 +212,7 @@ resource "azurerm_public_ip" "redpanda" {
   resource_group_name = azurerm_resource_group.redpanda.name
   location            = azurerm_resource_group.redpanda.location
   allocation_method   = "Static"
-  zones               = try([var.availability_zones[0]], [])
+  zones               = try([var.availability_zone[0]], [])
   sku                 = "Standard"
 
   tags = {
@@ -251,7 +251,7 @@ resource "azurerm_public_ip" "redpanda_client" {
   resource_group_name = azurerm_resource_group.redpanda.name
   location            = azurerm_resource_group.redpanda.location
   allocation_method   = "Static"
-  zones               = try([var.availability_zones[count.index % length(var.availability_zones)]], [])
+  zones               = try([var.availability_zone[count.index % length(var.availability_zone)]], [])
   sku                 = "Standard"
 
   tags = {
@@ -290,7 +290,7 @@ resource "azurerm_public_ip" "monitoring" {
   resource_group_name = azurerm_resource_group.redpanda.name
   location            = azurerm_resource_group.redpanda.location
   allocation_method   = "Static"
-  zones               = try([var.availability_zones[0]], [])
+  zones               = try([var.availability_zone[0]], [])
   sku                 = "Standard"
 
   tags = {

--- a/azure/vars.tf
+++ b/azure/vars.tf
@@ -3,9 +3,10 @@ variable "region" {
   default     = "centralus"
 }
 
-variable "availability_zones" {
+variable "availability_zone" {
   description = "Availability Zones to deploy to - this can either be null or an array of zones"
   default     = null
+  type        = list(string)
 }
 
 variable "network_range" {


### PR DESCRIPTION
Simple change to bring the name and type of the availability zone parameter to align it with the AWS and GCP implementations.