### PR TITLE
fix for aws standard main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,25 @@ Azure, or IBM.
 
 ```
 # Set required ansible variables
+export CLOUD_PROVIDER=aws
 export ANSIBLE_COLLECTIONS_PATHS=${PWD}/artifacts/collections
 export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
-export ANSIBLE_INVENTORY=$PWD/hosts.ini
+export ANSIBLE_INVENTORY=${PWD}/${CLOUD_PROVIDER}/hosts.ini
+
+# Assumes default private and public key names, if these aren't correct for you set them to the correct values
 
 # Deploy VM
-cd <cloud-provider>
+# ASSUMES YOU HAVE A DEFAULT VPC, if you don't set vpc_id and subnet_id
+cd $CLOUD_PROVIDER
 terraform init
-terraform apply --auto-approve
+terraform apply --auto-approve -var='public_key_path=~/.ssh/id_rsa.pub'
 
 # Install collections and roles
 ansible-galaxy install -r ./requirements.yml
 
 # Run a Playbook
-ansible-playbook ansible/<<<PLAYBOOK NAME>>>.yml --private-key <<<YOUR PRIVATE KEY LOCATION>>>
+# You need to pick the correct playbook for you, in this case we picked provision-basic-cluster
+ansible-playbook ansible/provision-basic-cluster.yml --private-key ~/.ssh/id_rsa
 ```
 
 ## Installation Prerequisites

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -90,7 +90,7 @@ tasks:
       you won't have to worry about loading them as DA_AWS* because you'll override it. So it will just work.
     dir: '{{.CLOUD_PROVIDER}}'
     vars:
-      HOSTS_FILE_LOC: '{{.ARTIFACT_DIR}}/hosts_{{.CLOUD_PROVIDER}}_{{.DEPLOYMENT_ID}}.ini'
+      ANSIBLE_INVENTORY: '{{ .ANSIBLE_INVENTORY }}'
     cmds:
       - |
         terraform init
@@ -103,7 +103,7 @@ tasks:
           -var='allow_force_destroy={{.ALLOW_FORCE_DESTROY}}' \
           -var='vpc_id={{.VPC_ID}}' \
           -var='distro={{.DISTRO}}' \
-          -var='hosts_file={{.HOSTS_FILE_LOC}}' \
+          -var='hosts_file={{.ANSIBLE_INVENTORY}}' \
           {{.CLI_ARGS}}
 
   import:
@@ -117,7 +117,7 @@ tasks:
       you won't have to worry about loading them as DA_AWS* because you'll override it. So it will just work.
     dir: '{{.CLOUD_PROVIDER}}'
     vars:
-      HOSTS_FILE_LOC: '{{.ARTIFACT_DIR}}/hosts_{{.CLOUD_PROVIDER}}_{{.DEPLOYMENT_ID}}.ini'
+      ANSIBLE_INVENTORY: '{{ .ANSIBLE_INVENTORY }}'
     cmds:
       - |
         terraform import {{.TF_SSH_USER_VAR}} \
@@ -129,7 +129,7 @@ tasks:
           -var='allow_force_destroy={{.ALLOW_FORCE_DESTROY}}' \
           -var='vpc_id={{.VPC_ID}}' \
           -var='distro={{.DISTRO}}' \
-          -var='hosts_file={{.HOSTS_FILE_LOC}}' \
+          -var='hosts_file={{.ANSIBLE_INVENTORY}}' \
           {{.CLI_ARGS}}
 
   destroy:
@@ -144,7 +144,7 @@ tasks:
       you won't have to worry about loading them as DA_AWS* because you'll override it. So it will just work.
     dir: '{{.CLOUD_PROVIDER}}'
     vars:
-      HOSTS_FILE_LOC: '{{.ARTIFACT_DIR}}/hosts_{{.CLOUD_PROVIDER}}_{{.DEPLOYMENT_ID}}.ini'
+      ANSIBLE_INVENTORY: '{{ .ANSIBLE_INVENTORY }}'
     cmds:
       - |
         terraform destroy -auto-approve {{.TF_SSH_USER_VAR}} \
@@ -156,7 +156,7 @@ tasks:
         -var='allow_force_destroy={{.ALLOW_FORCE_DESTROY}}' \
         -var='vpc_id={{.VPC_ID}}' \
         -var='distro={{.DISTRO}}' \
-        -var='hosts_file={{.HOSTS_FILE_LOC}}' \
+        -var='hosts_file={{.ANSIBLE_INVENTORY}}' \
         {{.CLI_ARGS}}
 
   install-role-requirements:

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,17 +1,31 @@
+## we assume a default vpc. if you have one you want to use you will need to provide a vpc and subnet ID
+
 module "redpanda-cluster" {
-  source                 = "redpanda-data/redpanda-cluster/aws"
-  version                = "~> 0.1"
-  public_key_path        = var.public_key_path
-  nodes                  = var.nodes
-  deployment_prefix      = var.deployment_prefix
-  enable_monitoring      = var.enable_monitoring
-  tiered_storage_enabled = var.tiered_storage_enabled
-  allow_force_destroy    = var.allow_force_destroy
-  vpc_id                 = var.vpc_id
-  distro                 = var.distro
-  hosts_file             = var.hosts_file
-  tags                   = var.tags
-  availability_zone      = var.availability_zone
+  source                   = "redpanda-data/redpanda-cluster/aws"
+  version                  = "~> 0.1"
+  public_key_path          = var.public_key_path
+  nodes                    = var.nodes
+  deployment_prefix        = var.deployment_prefix
+  enable_monitoring        = var.enable_monitoring
+  tiered_storage_enabled   = var.tiered_storage_enabled
+  allow_force_destroy      = var.allow_force_destroy
+  vpc_id                   = var.vpc_id
+  distro                   = var.distro
+  hosts_file               = var.hosts_file
+  tags                     = var.tags
+  aws_region               = var.aws_region
+  associate_public_ip_addr = var.associate_public_ip_addr
+  subnet_id                = var.subnet_id
+  availability_zone        = var.availability_zone
+}
+
+variable "availability_zone" {
+  default = ["us-west-2a"]
+}
+
+variable "associate_public_ip_addr" {
+  default = true
+  type    = bool
 }
 
 variable "public_key_path" {
@@ -87,17 +101,16 @@ terraform {
   }
 }
 
-variable "region" {
+variable "subnet_id" {
+  default = ""
+  type    = string
+}
+
+variable "aws_region" {
   type    = string
   default = "us-west-2"
 }
 
 provider "aws" {
-  region = var.region
-}
-
-variable "availability_zone" {
-  description = "The AWS AZs to deploy the infrastructure on"
-  default     = ["us-west-2a"]
-  type        = list(string)
+  region = var.aws_region
 }


### PR DESCRIPTION
made it easier for users to pass in information necessary to start up a cluster with TF

standardized the inventory file declaration in taskfile to a single variable because why