### PR TITLE
fix missing type

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -21,6 +21,7 @@ module "redpanda-cluster" {
 
 variable "availability_zone" {
   default = ["us-west-2a"]
+  type    = list(string)
 }
 
 variable "associate_public_ip_addr" {


### PR DESCRIPTION
Fixes an issue that can occur with a missing type defaulting to string rather than dynamically assigning list(string)