### PR TITLE
test: add basic cluster test and add registry bits

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,16 @@ agents:
   queue: "k8s-builders"
 
 steps:
+  - label: test basic cluster standup ubuntu
+    key: basic-up-ubuntu
+    command: .buildkite/scripts/standup-cluster.sh --prefix=rp-basic-ub --distro=ubuntu-focal --tiered=false --unstable=false --taskname=basic-cluster
+    plugins:
+      - docker#v5.4.0:
+          image: glrp/atgt:latest
+          environment:
+            - DA_AWS_ACCESS_KEY_ID
+            - DA_AWS_SECRET_ACCESS_KEY
+            - AWS_DEFAULT_REGION
   - label: test tiered-storage-up cluster standup ubuntu
     key: tiered-up-ubuntu
     command: .buildkite/scripts/standup-cluster.sh --prefix=rp-tier-ub --distro=ubuntu-focal --tiered=true --unstable=false --taskname=tiered-storage-cluster

--- a/.buildkite/scripts/test-basic-cluster.sh
+++ b/.buildkite/scripts/test-basic-cluster.sh
@@ -36,6 +36,13 @@ sed 's/$/:9092/' | \
 tr '\n' ',' | \
 sed 's/,$/\n/')
 
+export REDPANDA_REGISTRY=$(sed -n '/^\[redpanda\]/,/^$/p' "${PATH_TO_HOSTS_FILE}" | \
+grep 'private_ip=' | \
+cut -d' ' -f1 |  \
+sed 's/$/:8081/' | \
+tr '\n' ',' | \
+sed 's/,$/\n/')
+
 ## test that we can check status, create a topic and produce to the topic
 echo "checking cluster status"
 "${PATH_TO_RPK_FILE}" cluster status --brokers "$REDPANDA_BROKERS" -v || exit 1
@@ -48,3 +55,6 @@ echo squirrel | "${PATH_TO_RPK_FILE}" topic produce testtopic --brokers "$REDPAN
 
 echo "consuming from topic"
 "${PATH_TO_RPK_FILE}" topic consume testtopic --brokers "$REDPANDA_BROKERS" -v -o :end | grep squirrel || exit 1
+
+echo "testing schema registry"
+for ip_port in $(echo $REDPANDA_REGISTRY | tr ',' ' '); do curl $ip_port/subjects ; done 

--- a/.buildkite/scripts/test-tiered-storage-cluster.sh
+++ b/.buildkite/scripts/test-tiered-storage-cluster.sh
@@ -44,6 +44,13 @@ sed 's/$/:9092/' | \
 tr '\n' ',' | \
 sed 's/,$/\n/')
 
+export REDPANDA_REGISTRY=$(sed -n '/^\[redpanda\]/,/^$/p' "${PATH_TO_HOSTS_FILE}" | \
+grep 'private_ip=' | \
+cut -d' ' -f1 |  \
+sed 's/$/:8081/' | \
+tr '\n' ',' | \
+sed 's/,$/\n/')
+
 ## test that we can check status, create a topic and produce to the topic
 echo "checking cluster status"
 "${PATH_TO_RPK_FILE}" cluster status --brokers "$REDPANDA_BROKERS" --tls-truststore "$PATH_TO_CA_CRT" -v || exit 1
@@ -62,6 +69,9 @@ sleep 30
 echo "consuming from topic"
 testoutput=$("${PATH_TO_RPK_FILE}" topic consume testtopic --brokers "$REDPANDA_BROKERS" --tls-truststore "$PATH_TO_CA_CRT" -v -o :end)
 echo $testoutput | grep squirrels || exit 1
+
+echo "testing schema registry"
+for ip_port in $(echo $REDPANDA_REGISTRY | tr ',' ' '); do curl $ip_port/subjects -k --cacert "$PATH_TO_CA_CRT" ; done 
 
 echo "checking that bucket is not empty"
 # Check if the bucket is empty

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -132,6 +132,18 @@ tasks:
       - task: basic
         vars: { ANSIBLE_PLAYBOOK: "provision-tls-cluster.yml" }
 
+  create-basic-cluster:
+    desc: run multiple ansible playbooks to create a basic cluster
+    summary: |
+      This command assumes you have the infrastructure in place and does not build it for you.
+      Ensure you have a hosts file in the artifacts directory with name hosts_[CLOUD_PROVIDER]_[DEPLOYMENT_ID].ini
+    deps:
+      - install-role-requirements
+    run: always
+    cmds:
+      - task: basic
+        vars: { ANSIBLE_PLAYBOOK: "provision-basic-cluster.yml" }
+
   create-tiered-storage-cluster:
     desc: run multiple ansible playbooks to create a cluster with tls
     summary: |


### PR DESCRIPTION
Registry is enabled by default now, so we want to
test this for now using curl.

Once `rpk registry` is released we need to change
this test to use rpk.