### PR TITLE
fix: pin grafana version

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,6 +4,7 @@ collections:
     type: galaxy
   - name: ansible.posix
   - name: grafana.grafana
+    version: 5.6.0
   - name: prometheus.prometheus
 
 roles:


### PR DESCRIPTION
There's a bug in the latest grafana role that causes issues with deploying it as part of testing. I've pinned to 5.6.0 until they've resolved the issue

https://github.com/grafana/grafana-ansible-collection/issues/320