### PR TITLE
Feat: add syslog-ng support to operation-configure-logging playbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+This repository contains Terraform and Ansible configuration for automating the deployment of Redpanda clusters across multiple cloud providers (AWS, GCP, Azure, IBM). It provides infrastructure provisioning via Terraform and service deployment/configuration via Ansible playbooks.
+
+## Common Development Commands
+
+### Prerequisites Setup
+```bash
+# Install Ansible collections and roles
+make ansible-prereqs
+# OR manually:
+export ANSIBLE_COLLECTIONS_PATH=${PWD}/artifacts/collections
+export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
+ansible-galaxy collection install -r requirements.yml --force -p $ANSIBLE_COLLECTIONS_PATH
+ansible-galaxy role install -r requirements.yml --force -p $ANSIBLE_ROLES_PATH
+```
+
+### Key Generation
+```bash
+make keygen  # Creates artifacts/testkey and artifacts/testkey.pub
+```
+
+### Infrastructure Deployment
+
+#### AWS
+```bash
+# Build AWS infrastructure
+make build-aws
+# Full deployment with monitoring and console
+make aws-rp
+
+# With TLS
+make ci-aws-rp-tls
+
+# With tiered storage
+make ci-aws-rp-tiered
+
+# Clean up
+make destroy-aws
+```
+
+#### GCP
+```bash
+# Build GCP infrastructure  
+make build-gcp
+# Full deployment
+make ci-gcp-rp
+
+# Clean up
+make destroy-gcp
+```
+
+### Service Deployment
+```bash
+# Deploy Redpanda cluster
+make cluster
+
+# Deploy with TLS
+make cluster-tls
+
+# Deploy monitoring stack (Prometheus/Grafana)
+make monitor
+
+# Deploy Redpanda Console
+make console
+
+# Deploy Redpanda Connect
+make deploy-connect
+```
+
+### Testing
+```bash
+# Test cluster connectivity and basic operations
+make test-cluster
+
+# Test TLS-enabled cluster
+make test-cluster-tls
+
+# Test schema registry
+make test-schema
+```
+
+### Linting
+```bash
+make lint  # Runs ansible-lint
+```
+
+## Repository Architecture
+
+### Directory Structure
+- `ansible/` - Ansible playbooks for service deployment and configuration
+  - `provision-cluster*.yml` - Main cluster deployment playbooks  
+  - `deploy-monitor*.yml` - Monitoring stack deployment
+  - `deploy-console*.yml` - Console deployment
+  - `deploy-connect*.yml` - Connect deployment
+  - `operation-*.yml` - Operational tasks (logging, restart, license)
+  - `airgap/` - Air-gapped deployment configurations
+  - `proxy/` - Proxy-based deployment configurations
+  - `tls/` - TLS certificates and configurations
+
+- `aws/`, `gcp/`, `azure/`, `ibm/` - Cloud-specific Terraform configurations
+- `artifacts/` - Generated artifacts, logs, keys, and downloaded dependencies
+  - `collections/` - Ansible collections
+  - `roles/` - Ansible roles
+  - `logs/` - Deployment logs
+
+### Key Configuration Files
+- `Makefile` - Primary build and deployment automation
+- `requirements.yml` - Ansible collections and roles dependencies
+- `ansible.cfg` - Ansible configuration with SSH optimizations
+- `.ansible-lint` - Linting configuration with skip rules for production use
+
+### Cloud Provider Support
+Each cloud provider directory (`aws/`, `gcp/`, `azure/`, `ibm/`) contains:
+- `main.tf` - Primary Terraform configuration
+- `README.md` - Provider-specific documentation
+- `private-test/` - Alternative configurations for private/proxy deployments
+
+### Environment Variables
+Key environment variables used by Make targets:
+- `DEPLOYMENT_ID` - Unique identifier for the deployment
+- `NUM_NODES` - Number of Redpanda broker nodes (default: 3)
+- `ENABLE_MONITORING` - Enable Prometheus/Grafana stack
+- `TIERED_STORAGE_ENABLED` - Enable tiered storage features
+- `CLOUD_PROVIDER` - Target cloud provider (aws, gcp, azure, ibm)
+- `ANSIBLE_INVENTORY` - Path to generated inventory file
+- `REDPANDA_LICENSE` - License for Redpanda Enterprise features
+
+### Ansible Integration
+The repository uses a custom Redpanda Ansible collection (`redpanda.cluster`) along with community collections for monitoring (Grafana, Prometheus) and system setup. The collection is currently sourced from a development branch for testing new features.
+
+### Development Workflow
+1. Set environment variables for your target deployment
+2. Generate SSH keys with `make keygen`
+3. Deploy infrastructure with cloud-specific make targets
+4. Deploy services with Ansible playbooks
+5. Test deployment with provided test targets
+6. Clean up with destroy targets
+
+### TLS and Security
+The repository supports both plaintext and TLS-encrypted deployments. TLS configurations use self-signed certificates generated in the `ansible/tls/` directory. All sensitive operations use proper SSH key management and secure defaults.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,73 @@ You might try resolving by setting an environment variable:
 
 See: https://stackoverflow.com/questions/50168647/multiprocessing-causes-python-to-crash-and-gives-an-error-may-have-been-in-progr
 
+### Ansible Collection Caching Issues
+
+If you're experiencing issues where Ansible is using outdated versions of collections (e.g., local changes to the `redpanda-ansible-collection` are not being picked up), this is likely due to multiple cached versions of collections in different locations.
+
+**Symptoms:**
+- Local changes to collection roles/tasks are not reflected in playbook execution
+- Debug tasks or modifications don't appear in ansible-playbook output
+- Role behavior doesn't match your local code changes
+
+**Root Cause:**
+Ansible searches for collections in this priority order:
+1. Playbook-adjacent `collections/` directory
+2. `ANSIBLE_COLLECTIONS_PATH` (your local artifacts)
+3. `~/.ansible/collections/` (user cache) ⚠️ **Common problem source**
+4. System paths (`/usr/share/ansible/collections`)
+
+**Solutions:**
+
+**Option 1: Clear Caches and Set Environment Variables (Recommended)**
+```bash
+# Clear old cached versions
+rm -rf ~/.ansible/collections/ansible_collections/redpanda
+rm -rf ./gcp/artifacts/collections
+rm -rf ./*/artifacts/collections  # Clear any cloud-specific caches
+
+# Set environment variables (add to ~/.bashrc for persistence)
+export ANSIBLE_COLLECTIONS_PATH=${PWD}/artifacts/collections
+export ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles
+
+# Reinstall collections
+ansible-galaxy collection install -r requirements.yml --force -p ./artifacts/collections
+
+# Run playbooks
+ansible-playbook ansible/operation-configure-logging.yml
+```
+
+**Option 2: Use Inline Environment Variables**
+```bash
+ANSIBLE_COLLECTIONS_PATH=${PWD}/artifacts/collections ANSIBLE_ROLES_PATH=${PWD}/artifacts/roles ansible-playbook ansible/operation-configure-logging.yml
+```
+
+**Option 3: Create a Cleanup Script**
+```bash
+#!/bin/bash
+# cleanup-ansible-cache.sh
+echo "Cleaning ansible caches..."
+rm -rf ~/.ansible/collections/ansible_collections/redpanda
+rm -rf ./gcp/artifacts/collections
+rm -rf ./aws/artifacts/collections
+rm -rf ./azure/artifacts/collections
+rm -rf ./ibm/artifacts/collections
+echo "Caches cleared!"
+```
+
+**Option 4: Use ansible.cfg Configuration**
+Modify your `ansible.cfg` to prioritize local collections:
+```ini
+[defaults]
+collections_paths = ./artifacts/collections:~/.ansible/collections:/usr/share/ansible/collections
+roles_path = ./artifacts/roles:~/.ansible/roles:/usr/share/ansible/roles
+```
+
+**Prevention:**
+- Always set `ANSIBLE_COLLECTIONS_PATH` and `ANSIBLE_ROLES_PATH` environment variables before development
+- Use `--force` flag when installing collections during development
+- Clear caches when switching between different versions of collections
+
 ## Contribution Guide
 
 ### testing with a specific branch of redpanda-ansible-collection

--- a/ansible/operation-configure-logging.yml
+++ b/ansible/operation-configure-logging.yml
@@ -10,6 +10,8 @@
       ansible.builtin.shell: |
         set -o pipefail
         {{ rpk_bin }} cluster health | grep -i 'healthy:' | tr -d '[:space:]' | awk -F ':' '{print tolower($2)}'
+      args:
+        executable: /bin/bash
       register: health_check
       run_once: true
       failed_when: "health_check.stdout != 'true'"
@@ -31,8 +33,15 @@
       ansible.builtin.stat:
         path: "/etc/rsyslog.d/{{ redpanda_logging_rsyslog_priority | default('40') }}-redpanda.conf"
       register: rsyslog_config_check
-      when: redpanda_logging_rsyslog_enabled | default(true)
+      when: redpanda_logging_backend | default('rsyslog') == 'rsyslog'
       failed_when: not rsyslog_config_check.stat.exists
+
+    - name: Verify syslog-ng configuration
+      ansible.builtin.stat:
+        path: "/etc/syslog-ng/conf.d/{{ redpanda_logging_syslog_ng_priority | default('40') }}-redpanda.conf"
+      register: syslog_ng_config_check
+      when: redpanda_logging_backend | default('rsyslog') == 'syslog-ng'
+      failed_when: not syslog_ng_config_check.stat.exists
 
     - name: Verify logrotate configuration
       ansible.builtin.stat:
@@ -60,6 +69,8 @@
       ansible.builtin.shell: |
         set -o pipefail
         {{ rpk_bin }} redpanda admin brokers list | grep -q 'active.*true'
+      args:
+        executable: /bin/bash
       register: broker_status
       changed_when: false
       failed_when: broker_status.rc != 0
@@ -69,6 +80,6 @@
         msg:
           - "Redpanda logging configuration completed"
           - "Log file: {{ redpanda_logging_log_file | default('/var/log/redpanda.log') }}"
-          - "Rsyslog: {{ 'enabled' if (redpanda_logging_rsyslog_enabled | default(true)) else 'disabled' }}"
+          - "Backend: {{ redpanda_logging_backend | default('rsyslog') }}"
           - "Logrotate: {{ 'enabled' if (redpanda_logging_logrotate_enabled | default(true)) else 'disabled' }}"
       run_once: true


### PR DESCRIPTION
- Add verification checks for syslog-ng configuration files
- Update backend detection to use redpanda_logging_backend variable
- Modify summary display to show selected logging backend
- Maintain backward compatibility with rsyslog as default backend
- Specify bash executable explicitly in shell tasks for improved reliability
- Add comprehensive documentation for Ansible collection caching troubleshooting

This enhancement allows the logging operation to work with both rsyslog and syslog-ng backends, matching the capabilities added in the redpanda-ansible-collection.

Related redpanda-ansible-collection PR [here](https://github.com/redpanda-data/redpanda-ansible-collection/pull/132)

🤖 Generated with [Claude Code](https://claude.ai/code)