### PR TITLE
buildkite: migrate from k8s-builders to k8s-m6ixlarge pool

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: "k8s-builders"
+  queue: "k8s-m6ixlarge"
 
 steps:
   - label: aws ubuntu


### PR DESCRIPTION
## Summary

Migrate Buildkite pipeline from the manually-deployed `k8s-builders` pool to the Terraform-managed `k8s-m6ixlarge` pool (m6i.xlarge).

Part of [DEVPROD-2815](https://redpandadata.atlassian.net/browse/DEVPROD-2815).

[DEVPROD-2815]: https://redpandadata.atlassian.net/browse/DEVPROD-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ