### PR TITLE
test: pin redpanda.cluster to the UUID data-mount branch for CI

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,8 @@
 collections:
   - name: community.general
-  - name: redpanda.cluster
-    type: galaxy
+  - name: https://github.com/redpanda-data/redpanda-ansible-collection.git
+    type: git
+    version: fix/node-id-substring-match
   - name: ansible.posix
   - name: grafana.grafana
     version: 5.6.0


### PR DESCRIPTION
Temporarily source the redpanda.cluster collection from the fix/node-id-substring-match branch (git) instead of Galaxy so CI exercises the UUID-based data-volume mounting changes end-to-end. 